### PR TITLE
refactor(webpack): humanized gitRemote getter

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,9 @@ const globule = require('globule');
 const filepaths = globule.find('src/**/*.html');
 const {BaseHrefWebpackPlugin} = require('base-href-webpack-plugin');
 const openBrowser = require('react-dev-utils/openBrowser');
+const { execSync } = require('child_process');
 
-var gitRemote = require('child_process').execSync('git remote get-url origin').toString();
+const gitRemote = execSync('git remote get-url origin', { encoding: 'utf8' });
 const gitSearch = /(git@|https:\/\/)([\w\.@]+)(\/|:)([\w,\-,\_]+)\/([\w,\-,\_]+)(.git){0,1}((\/){0,1})/
 
 const repositoryName = gitRemote && gitRemote.match(gitSearch) && gitRemote.match(gitSearch)[5]


### PR DESCRIPTION
This PR aims to:

- humanize the getting of the git remote origin url
- set gitRemote variable as const (there is no reason why it should remain `var`, because its value is not reassigned somewhere)